### PR TITLE
remove unused param and var

### DIFF
--- a/themes/judd-foundation/template-parts/content-hero-carousel.php
+++ b/themes/judd-foundation/template-parts/content-hero-carousel.php
@@ -90,9 +90,8 @@
         <!-- get featured image -->
 <?php
 $thumb_id = get_post_thumbnail_id();
-$thumb_url_array = wp_get_attachment_image_src($thumb_id, 'thumbnail-size', true, $attr);
+$thumb_url_array = wp_get_attachment_image_src($thumb_id, 'thumbnail-size', true);
 $thumb_url = $thumb_url_array[0];
-$thumb_caption = $thumb_id->post_excerpt;
 ?>
         <div data-p="225.00">
             <img data-u="image" src="<?php echo $thumb_url; ?>" style="height: 100%; width: auto;"/>


### PR DESCRIPTION
<img width="1680" alt="screenshot 2016-10-18 09 37 14" src="https://cloud.githubusercontent.com/assets/735430/19502588/101e28fa-957c-11e6-97de-590ddcfd4b6d.png">

The live site has a few pages where these errors are visible behind the loading hero.

line 93: Looks like we can do without `$attr` as that function only takes 3 params:
https://developer.wordpress.org/reference/functions/wp_get_attachment_image_src/#parameters

line 95: `$thumb_caption` isn't being used, and shouldn't be able to get this property out of a simple string anyway:
https://codex.wordpress.org/Function_Reference/get_post_thumbnail_id
